### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: "Deployment"
+permissions:
+  contents: write
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/Arkapravo-Ghosh/birthday-card-generator/security/code-scanning/1](https://github.com/Arkapravo-Ghosh/birthday-card-generator/security/code-scanning/1)

Generally, the fix is to add an explicit `permissions` section to the workflow (either at the root or for the specific job) that grants only the scopes required for deployment. Since this job uses `GITHUB_TOKEN` to push to the repository (Git remote is set with that token and deploy scripts typically push to a Pages branch), it needs `contents: write`. No other special scopes are clearly required from the snippet, so we can limit permissions to that single capability.

The best fix with minimal functional change is to add a workflow-level `permissions` block directly under the `name` (or `on`) section in `.github/workflows/main.yml` setting `contents: write`. This will apply to all jobs (here only `deploy-to-gh-pages`) and makes it explicit that the token is allowed to write repository contents, which matches the current behavior implied by the git push setup. We don’t change any steps or logic, only the token permissions. Concretely, insert:

```yaml
permissions:
  contents: write
```

between the existing `name: "Deployment"` line and the `on:` block. No extra imports or additional definitions are needed, since this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
